### PR TITLE
Add missing "publish" npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "fix": "wireit",
     "fix:eslint": "wireit",
     "fix:prettier": "wireit",
+    "publish": "wireit",
     "test": "DEBUG_PRINT_LIMIT=2147483647 __NEXT_TEST_MODE=jest jest"
   },
   "types": "dist/index.d.ts",


### PR DESCRIPTION
I'm sorry, I added the `publish` script to wireit's config in #27 but forgot to add it to package.json's `scripts`, leading to [this error](https://github.com/apollo-server-integrations/apollo-server-integration-next/actions/runs/3420239761/jobs/5694797497).