### PR TITLE
Allow startServerAndCreateNextHandler to accept custom types

### DIFF
--- a/src/startServerAndCreateNextHandler.ts
+++ b/src/startServerAndCreateNextHandler.ts
@@ -17,6 +17,7 @@ const defaultContext: ContextFunction<[], any> = async () => ({});
 
 function startServerAndCreateNextHandler<
   Req extends HandlerRequest = NextApiRequest,
+  ResponseBody = unknown,
   Context extends BaseContext = object,
 >(server: ApolloServer<Context>, options?: Options<Req, Context>) {
   server.startInBackgroundHandlingStartupErrorsByLoggingAndFailingAllRequests();
@@ -24,7 +25,7 @@ function startServerAndCreateNextHandler<
   const contextFunction = options?.context || defaultContext;
 
   async function handler<HandlerReq extends NextApiRequest>(req: HandlerReq, res: NextApiResponse): Promise<unknown>;
-  async function handler<HandlerReq extends NextRequest | Request>(req: HandlerReq, res?: undefined): Promise<Response>;
+  async function handler<HandlerReq extends NextRequest | Request>(req: HandlerReq, res?: undefined): Promise<ResponseBody>;
   async function handler(req: HandlerRequest, res: NextApiResponse | undefined) {
     const httpGraphQLResponse = await server.executeHTTPGraphQLRequest({
       context: () => contextFunction(req as Req, res as Req extends NextApiRequest ? NextApiResponse : undefined),

--- a/src/startServerAndCreateNextHandler.ts
+++ b/src/startServerAndCreateNextHandler.ts
@@ -3,7 +3,7 @@ import { getHeaders } from './lib/getHeaders';
 import { isNextApiRequest } from './lib/isNextApiRequest';
 import { ApolloServer, BaseContext, ContextFunction } from '@apollo/server';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { parse } from 'url';
 
 type HandlerRequest = NextApiRequest | NextRequest | Request;
@@ -25,7 +25,7 @@ function startServerAndCreateNextHandler<
   const contextFunction = options?.context || defaultContext;
 
   async function handler<HandlerReq extends NextApiRequest>(req: HandlerReq, res: NextApiResponse): Promise<unknown>;
-  async function handler<HandlerReq extends NextRequest | Request>(req: HandlerReq, res?: undefined): Promise<ResponseBody>;
+  async function handler<HandlerReq extends NextRequest | Request>(req: HandlerReq, res?: undefined): Promise<NextResponse<ResponseBody>>;
   async function handler(req: HandlerRequest, res: NextApiResponse | undefined) {
     const httpGraphQLResponse = await server.executeHTTPGraphQLRequest({
       context: () => contextFunction(req as Req, res as Req extends NextApiRequest ? NextApiResponse : undefined),


### PR DESCRIPTION
This PR intends to solve this reported issue below
https://github.com/apollo-server-integrations/apollo-server-integration-next/issues/121

Route Handlers in Next.js 13 accept a generic type, as shown below. But this would cause a TypeScript error when being used with `startServerAndCreateNextHandler` as reported in the issue above. 


```ts
export async function POST(
  req: NextRequest,
): Promise<NextResponse<GraphQlResponseBody>>{
  return (await handler(req));
}
``` 

To solve this issue, I believe that the original type from Next.js should be returned from the line below instead of the `Response` and be allowed to accept the optional generic type
`async function handler<HandlerReq extends NextRequest | Request>(req: HandlerReq, res?: undefined): Promise<Response>;`
The above code should return the `NextResponse` type as shown below

`async function handler<HandlerReq extends NextRequest | Request>(req: HandlerReq, res?: undefined): Promise<NextResponse<ResponseBody>>;`

After this PR the `` can be used like this with no problem

```ts
// GraphQlResponseBody is a custom type depending on what my server should return
const handler = startServerAndCreateNextHandler<NextRequest, GraphQlResponseBody>(apolloServer);

// Assign the correct type to Next Route handler with no issue
export async function POST(
  req: NextRequest,
): Promise<NextResponse<GraphQlResponseBody>> {
  return await handler(req);
}
```


