### PR TITLE
Return void for API routes

### DIFF
--- a/src/startServerAndCreateNextHandler.ts
+++ b/src/startServerAndCreateNextHandler.ts
@@ -55,7 +55,8 @@ function startServerAndCreateNextHandler<
         }
       }
 
-      return res.end();
+      res.end();
+      return;
     }
 
     const body = [];


### PR DESCRIPTION
Fixes #116 

API routes should not return a value, but when we return the result of `res.end()` we end up returning the instance of `NextApiResponse`.

Doing this leads to the following warning in Next.js:
> API handler should not return a value, received object.