### PR TITLE
Changes to the incremental responses

### DIFF
--- a/.changeset/witty-pens-nail.md
+++ b/.changeset/witty-pens-nail.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/next': minor
+---
+
+Add support for incremental delivery

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An Apollo Server integration for use with Next.js.
 First create a Next.js API route by creating a file at for example `pages/api/graphql.js`.  
 This API route will be accessible at `/api/graphql`.
 
-Next create an Apollo Server instance and pass it to `startServerAndCreateNextHandler`:
+Next, create an Apollo Server instance and pass it to `startServerAndCreateNextHandler`:
 
 ```js
 import { ApolloServer } from '@apollo/server';
@@ -46,15 +46,11 @@ The Next.js `req` and `res` objects are passed along to the context function.
 
 ## App Router (Route Handlers)
 
-This integration has experimental support for [Next.js' App Router](https://nextjs.org/docs/app/building-your-application/routing/router-handlers), which is now the stable and default project structure for Next.js.
+First create a Next.js Route Handler by creating a file at for example `app/api/graphql/route.js`.  
+This Route Handler will be accessible at `/api/graphql`.
 
-Make sure you're on recent version of Next.js (13.4+), then create a new Route
-Handler file, for example at `app/api/graphql/route.js`.
-
-This file's route handlers will be accessible at URI path `/api/graphql`.
-
-Next create an Apollo Server instance, pass it to `startServerAndCreateNextHandler` and
-finally pass the handler to both a GET and a POST route handler:
+Next, create an Apollo Server instance, pass it to `startServerAndCreateNextHandler` and  
+finally export the handler both as GET and POST:
 
 ```js
 import { startServerAndCreateNextHandler } from '@as-integrations/next';
@@ -83,7 +79,7 @@ const handler = startServerAndCreateNextHandler(server);
 export { handler as GET, handler as POST };
 ```
 
-## Typescript
+## TypeScript
 
 When using this integration with Route Handlers you will have to specify the type of the incoming request object (`Response` or `NextResponse`) for the context function to receive the correct type signature:
 

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -56,7 +56,6 @@ describe('nextHandler', () => {
       };
     },
     {
-      noIncrementalDelivery: true,
       serverIsStartedInBackground: true,
     },
   );


### PR DESCRIPTION
Fixes: https://github.com/apollo-server-integrations/apollo-server-integration-next/issues/203

Preface: This is my first exposure to working with these Node objects on the server side so I'm not entirely sure if what I've done is correct.

I changed the way the incremental responses are sent back to the client. In the issue I noted 

```
      for await (const chunk of httpGraphQLResponse.body.asyncIterator) {
        body.push(chunk);
      }
```

this `await` is stopping the server from incrementally delivering the responses and instead they're all delivered at once.

These changes allow the responses to be streamed back instead of all at once. 

The logs in the client now show
```
what is data? {book: {…}} false 12:22:18
what is data? {book: {…}} false 12:22:19
```

Where the second `book: {}` has the deferred data and is delivered 1 second after the first in which the 1 second is hard coded in my project using this package.
