### PR TITLE
Replace deprecated url.parse with the WHATWG URL API

### DIFF
--- a/.changeset/calm-urls-rest.md
+++ b/.changeset/calm-urls-rest.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/next': patch
+---
+
+Replace the deprecated `url.parse()` call with the WHATWG URL API.

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -1,11 +1,56 @@
 import { startServerAndCreateNextHandler } from '../startServerAndCreateNextHandler';
-import { ApolloServer, ApolloServerOptions, BaseContext } from '@apollo/server';
+import { ApolloServer, ApolloServerOptions, BaseContext, HeaderMap } from '@apollo/server';
 import {
   CreateServerForIntegrationTestsOptions,
   defineIntegrationTestSuite,
 } from '@apollo/server-integration-testsuite';
 import { createServer } from 'http';
 import { AddressInfo } from 'net';
+import { NextApiRequest, NextApiResponse } from 'next';
+import * as legacyUrl from 'url';
+
+jest.mock('url', () => {
+  const actualUrl = jest.requireActual<typeof import('url')>('url');
+  return { ...actualUrl, parse: jest.fn(actualUrl.parse) };
+});
+
+describe('startServerAndCreateNextHandler', () => {
+  it('uses the WHATWG URL API for relative API route URLs', async () => {
+    const executeHTTPGraphQLRequest = jest.fn().mockResolvedValue({
+      body: { kind: 'complete', string: '{}' },
+      headers: new HeaderMap(),
+      status: 200,
+    });
+    const server = {
+      executeHTTPGraphQLRequest,
+      startInBackgroundHandlingStartupErrorsByLoggingAndFailingAllRequests: jest.fn(),
+    } as unknown as ApolloServer<BaseContext>;
+    const handler = startServerAndCreateNextHandler(server);
+    const request = {
+      body: undefined,
+      headers: {},
+      method: 'GET',
+      query: {},
+      url: '/api/graphql?operation=test%20query#fragment',
+    } as NextApiRequest;
+    const response = {
+      end: jest.fn(),
+      send: jest.fn(),
+      setHeader: jest.fn(),
+    } as unknown as NextApiResponse;
+    const legacyParse = jest.mocked(legacyUrl.parse);
+    legacyParse.mockClear();
+
+    await handler(request, response);
+
+    expect(legacyParse).not.toHaveBeenCalled();
+    expect(executeHTTPGraphQLRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpGraphQLRequest: expect.objectContaining({ search: '?operation=test%20query' }),
+      }),
+    );
+  });
+});
 
 async function getApiResolver() {
   let apiResolver;

--- a/src/startServerAndCreateNextHandler.ts
+++ b/src/startServerAndCreateNextHandler.ts
@@ -5,7 +5,6 @@ import { ApolloServer, BaseContext, ContextFunction } from '@apollo/server';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { NextRequest } from 'next/server';
 import { Readable } from 'stream';
-import { parse } from 'url';
 
 type HandlerRequest = NextApiRequest | NextRequest | Request;
 
@@ -33,7 +32,7 @@ function startServerAndCreateNextHandler<
         body: await getBody(req),
         headers: getHeaders(req),
         method: req.method || 'POST',
-        search: req.url ? parse(req.url).search || '' : '',
+        search: req.url ? new URL(req.url, 'http://localhost').search : '',
       },
     });
 


### PR DESCRIPTION
## Summary

- replace the deprecated `url.parse()` query extraction with the WHATWG `URL` API
- preserve encoded query strings for relative Next API route URLs
- add a regression that fails if the handler calls the legacy parser
- add a patch changeset

Fixes #320

## Test plan

- failure-before regression: one legacy parser call detected
- `npm run test` — Next.js 12, 13, 14, 15, and 16 suites pass
- Node 24 direct Next 16 Jest run — 247 passed, 24 skipped, 47 snapshots passed
- `npm run check` — changeset, ESLint, Prettier, and TypeScript checks pass
- Node 24 direct reproduction confirms the old API emits `DEP0169`
- `git diff --check`

Build note: the current TypeScript 6 dependency reports TS5011 for `tsconfig.build.json` because `rootDir` is not explicit; the same failure reproduces on an unmodified `main` worktree.